### PR TITLE
Do not append items to a list multiple times

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -32,9 +32,10 @@ class ItemsController < ApplicationController
     item = current_user.items.new item_params.merge(label_ids: current_label_ids)
 
     if item.save
-      # flash[:notice] = 'Item successfully created'
+      flash[:notice] = 'Item successfully created'
     else
-      flash[:alert] = 'Could not create item'
+      error_message = item.errors.full_messages.to_sentence
+      flash[:alert] = error_message
     end
     redirect_to action: :index, label_ids: current_label_id_params, focus_search: true
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,7 +11,7 @@ class Item < ApplicationRecord
 
   mount_uploader :image, ImageUploader
 
-  validates :name, presence: true
+  validates :name, presence: true, uniqueness: true
 
   after_create :scrape_in_background, unless: -> { Rails.env.test? }
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -11,7 +11,7 @@ class Item < ApplicationRecord
 
   mount_uploader :image, ImageUploader
 
-  validates :name, presence: true, uniqueness: true
+  validates :name, presence: true, uniqueness: { scope: [:user_id] }
 
   after_create :scrape_in_background, unless: -> { Rails.env.test? }
 

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -3,21 +3,28 @@ require 'test_helper'
 class ItemTest < ActiveSupport::TestCase
 
   test "Items must have unique names" do
-    user = create(:user)
     label = create(:label, name: 'Music')
     item1 = create(:item, name: 'pigeon', labels: [label])
-    item2 = Item.new(name: 'pigeon', labels: [label], user: user)
-    item3 = Item.new(name: 'Pigeon', labels: [label], user: user)
+    item2 = build(:item, name: 'pigeon', labels: [label], user: item1.user)
+    item3 = build(:item, name: 'Pigeon', labels: [label], user: item1.user)
     assert item1.valid?
-    assert_not item2.valid?
     assert item3.valid?
+    assert_not item2.valid?
+  end
+
+  test "Name has not to be unique when assigned to different users" do
+    label = create(:label, name: 'Music')
+    item1 = create(:item, name: 'pigeon', labels: [label])
+    item2 = create(:item, name: 'pigeon', labels: [label])
+    assert item1.valid?
+    assert item2.valid?
   end
 
   test "Items require a non-empty name" do
     user = create(:user)
     label = create(:label, name: 'Music')
-    item1 = Item.new(name: '', labels: [label], user: user)
-    item2 = Item.new(name: 'singstar adventures', labels: [label], user: user)
+    item1 = build(:item, name: '', labels: [label], user: user)
+    item2 = build(:item, name: 'singstar adventures', labels: [label], user: user)
     assert_not item1.valid?
     assert item2.valid?
   end

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -1,6 +1,27 @@
 require 'test_helper'
 
 class ItemTest < ActiveSupport::TestCase
+
+  test "Items must have unique names" do
+    user = create(:user)
+    label = create(:label, name: 'Music')
+    item1 = create(:item, name: 'pigeon', labels: [label])
+    item2 = Item.new(name: 'pigeon', labels: [label], user: user)
+    item3 = Item.new(name: 'Pigeon', labels: [label], user: user)
+    assert item1.valid?
+    assert_not item2.valid?
+    assert item3.valid?
+  end
+
+  test "Items require a non-empty name" do
+    user = create(:user)
+    label = create(:label, name: 'Music')
+    item1 = Item.new(name: '', labels: [label], user: user)
+    item2 = Item.new(name: 'singstar adventures', labels: [label], user: user)
+    assert_not item1.valid?
+    assert item2.valid?
+  end
+
   test ".with_labels(label_ids) returns items that are associated with one of label_ids" do
     label1 = create(:label, name: 'Music')
     label2 = create(:label, name: 'TV')


### PR DESCRIPTION
Addresses #21

<img width="1440" alt="screen shot 2017-02-28 at 09 42 07" src="https://cloud.githubusercontent.com/assets/827143/23399243/da5939f8-fd9f-11e6-807c-21debcdd26e1.png">


The uniqueness of an item is given by its name. If there is already an
item with the same name present in a user's list, then do not append it
to the list. Instead, display a flash message which informs the user
about this circumstance.