### PR TITLE
Generate documentation via rake task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 
 .env
 /public/uploads/*
+
+# Do not push generated doc files
+.yardoc/
+doc/
+erd.pdf

--- a/Gemfile
+++ b/Gemfile
@@ -79,6 +79,12 @@ group :development do
   # For style reviews
   gem 'pronto'
   gem 'pronto-rubocop', require: false
+
+  # A documentation generation tool
+  gem 'yard'
+
+  # Generate Entity-Relationship Diagrams
+  gem "rails-erd"
 end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -51,6 +51,7 @@ GEM
       activemodel (>= 4.0.0)
       activesupport (>= 4.0.0)
       mime-types (>= 1.16)
+    choice (0.2.0)
     clearance (1.16.0)
       bcrypt
       email_validator (~> 1.4)
@@ -163,6 +164,11 @@ GEM
     rails-dom-testing (2.0.2)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6)
+    rails-erd (1.5.0)
+      activerecord (>= 3.2)
+      activesupport (>= 3.2)
+      choice (~> 0.2.0)
+      ruby-graphviz (~> 1.2)
     rails-html-sanitizer (1.0.3)
       loofah (~> 2.0)
     railties (5.0.1)
@@ -183,6 +189,7 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-graphviz (1.2.2)
     ruby-progressbar (1.8.1)
     rugged (0.25.1.1)
     sass (3.4.23)
@@ -232,6 +239,7 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    yard (0.9.8)
     yui-compressor (0.12.0)
 
 PLATFORMS
@@ -258,6 +266,7 @@ DEPENDENCIES
   pry-rails
   puma
   rails (~> 5)
+  rails-erd
   sass-rails (~> 5.0)
   sidekiq
   spring
@@ -265,6 +274,7 @@ DEPENDENCIES
   turbolinks (~> 5)
   tzinfo-data
   web-console (>= 3.3.0)
+  yard
   yui-compressor (~> 0.12.0)
 
 RUBY VERSION

--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Make sure postgres and redis servers are running.
 bundle exec rake test
 ```
 
+## Generate Documentation
+
+```
+bundle exec rake docs
+```
+
 ## Contributing
 
 1. Fork this repository

--- a/lib/tasks/docs.rake
+++ b/lib/tasks/docs.rake
@@ -1,0 +1,6 @@
+desc "Generate Yard documentation of project source."
+task :docs do
+  system 'yardoc --no-private --protected app/**/*.rb'
+  system 'bundle exec erd'
+  puts "Generated docs `docs/` and UML diagram 'erd.pdf'."
+end


### PR DESCRIPTION
Running `rake docs` will generate the projects yard documentation,
which is located at `./docs` as well as a graphical ER-DB schema,
contained in `erb.pdf`.