### PR TITLE
Implemented Recipe Scraper

### DIFF
--- a/app/clients/discogs_client.rb
+++ b/app/clients/discogs_client.rb
@@ -1,7 +1,7 @@
 class DiscogsClient
   include HTTParty
   base_uri 'https://api.discogs.com'
-  default_params key: ENV['DISCOGS_KEY'], secret: ENV['DISCOGS_SECRET']
+  default_params key: ENV['DISCOGS_API_KEY'], secret: ENV['DISCOGS_API_SECRET']
   headers('User-Agent' => 'lists.rathr.io')
 
   def search(query, type: 'release')

--- a/app/clients/edamam_client.rb
+++ b/app/clients/edamam_client.rb
@@ -1,0 +1,10 @@
+class EdamamClient
+  include HTTParty
+  base_uri 'https://api.edamam.com'
+  default_params app_id: ENV['EDAMAM_API_ID'], app_key: ENV['EDAMAM_API_KEY']
+
+  def search(query)
+    params = { q: query }
+    self.class.get("/search", query: params)
+  end
+end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -9,6 +9,7 @@ class Label < ApplicationRecord
     user.labels.find_or_create_by(name: 'TV', scraper: 'TvScraper', fa_icon: 'television')
     user.labels.find_or_create_by(name: 'Music', scraper: 'AlbumScraper', fa_icon: 'music')
     user.labels.find_or_create_by(name: 'Games', scraper: 'GameScraper', fa_icon: 'gamepad')
+    user.labels.find_or_create_by(name: 'Recipes', scraper: 'RecipeScraper', fa_icon: 'cutlery')
   end
 
   def default_scraper

--- a/app/scrapers/recipe_scraper.rb
+++ b/app/scrapers/recipe_scraper.rb
@@ -1,0 +1,35 @@
+class RecipeScraper
+  include Scraper
+
+  def search_results
+    edamam_client.search(query.strip)['hits']
+  end
+
+  def scrape_name(result)
+    result['recipe']['label']
+  end
+
+  def scrape_description(result)
+    result['recipe']['ingredientLines'].join("\n")
+  end
+
+  def scrape_image(result)
+    result['recipe']['image']
+  end
+
+  def scrape_tags(result)
+    result['recipe']['healthLabels']
+  end
+
+  def scrape_links(result)
+    [
+      Link.new(url: result['recipe']['url'])
+    ]
+  end
+
+  private
+
+  def edamam_client
+    @edamam_client ||= EdamamClient.new
+  end
+end

--- a/app/scrapers/scraper.rb
+++ b/app/scrapers/scraper.rb
@@ -99,6 +99,7 @@ module Scraper
   def scrape_date(result)
   end
 
+  # @retun [Array<Link>] list of links extracted from result.
   def scrape_links(result)
     []
   end

--- a/db/migrate/20170302151706_add_new_recipe_label_to_users.rb
+++ b/db/migrate/20170302151706_add_new_recipe_label_to_users.rb
@@ -1,0 +1,7 @@
+class AddNewRecipeLabelToUsers < ActiveRecord::Migration[5.0]
+  def change
+    User.all.each do |user|
+      Label.create_defaults user
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170225184413) do
+ActiveRecord::Schema.define(version: 20170302151706) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
This patch a recipe scraper with a corresponding client plus a new default label _Recipe_.

Addresses Issue #24 

<img width="1440" alt="screen shot 2017-03-02 at 11 56 11" src="https://cloud.githubusercontent.com/assets/827143/23504355/5844be00-ff3f-11e6-9709-9355e37b6b06.png">

For the client I am relying on: https://developer.edamam.com/
This is so far the best free plan option (5000 requests per month)
Please sign up to aquire an API key (when signed in, goto https://developer.edamam.com/admin/applications/ and then to **Recipe Search API**).

Please notice the following: 
+ Existing users should regenerate their default labels by calling `Label.create_defaults(my_existing_user)`. Should we implement a taks that regenerates all defaults?
+ Please set the corresponding API tokens: `EDAMAM_APP_ID=MY_APP_ID` and `EDAMAM_APP_KEY=MY_APP_KEY`.
+ It looks like Recipes have many tags assigned to. However, rendering too many tags will cause an overflow in the layout (see screenshot). I suggest to restrict the number of tags rendered.