### PR TITLE
Prevent layout overflow when there are too any tags present

### DIFF
--- a/app/views/items/_item.html.erb
+++ b/app/views/items/_item.html.erb
@@ -30,7 +30,7 @@
           </div>
         <% end %>
 
-        <% item.tags.each do |tag| %>
+        <% item.tags.first(4).each do |tag| %>
           <div class="level-item is-hidden-touch">
             <%= link_to items_path(label_ids: current_label_id_params, tag_ids: tag.id) do %>
               <span class="tag is-light is-small">

--- a/app/views/scraper_results/_scraper_results.html.erb
+++ b/app/views/scraper_results/_scraper_results.html.erb
@@ -21,7 +21,7 @@
             </div>
           <% end %>
 
-          <% result.tags.each do |tag| %>
+          <% result.tags.first(4).each do |tag| %>
             <div class="level-item">
               <span class="tag is-light is-small">
                 <%= tag %>


### PR DESCRIPTION
Follow up PR of #24 

**Before**:
<img width="1440" alt="before_scraper" src="https://cloud.githubusercontent.com/assets/827143/23527311/c3627a64-ff95-11e6-9d61-8474635f69a6.png">

**After**:
<img width="1440" alt="after_scraper" src="https://cloud.githubusercontent.com/assets/827143/23527315/c5bdaa68-ff95-11e6-8b8b-3d98b062ebff.png">


