### PR TITLE
WIP: Filter irrelevant scraper results

### DIFF
--- a/app/scrapers/movie_scraper.rb
+++ b/app/scrapers/movie_scraper.rb
@@ -26,6 +26,10 @@ class MovieScraper
     result['genre_ids'].map { |id| MoviedbClient::GENRES[id] }.uniq.compact
   end
 
+  def reliable?(result)
+    result['popularity'] > 4
+  end
+
   private
 
   def moviedb_client

--- a/app/scrapers/scraper.rb
+++ b/app/scrapers/scraper.rb
@@ -60,7 +60,8 @@ module Scraper
         remote_image_url: scrape_image(result),
         date: scrape_date(result),
         links: scrape_links(result),
-        tags: scrape_tags(result)
+        tags: scrape_tags(result),
+        is_reliable: reliable?(result)
       }
     end
   end
@@ -106,5 +107,15 @@ module Scraper
 
   def scrape_tags(result)
     []
+  end
+
+  # Indicates whether this scraper result reliable and thus can be shown.
+  # 
+  # @param result [Hash] client response
+  # @info: Can be used to filter irrelevant / unpopular results, such as b-movies.
+  # @return [Boolean] indicates whether this scraper result is reliable.
+  #   By default every scraped result is reliable.
+  def reliable?(result)
+    true
   end
 end

--- a/app/scrapers/tv_scraper.rb
+++ b/app/scrapers/tv_scraper.rb
@@ -26,6 +26,10 @@ class TvScraper
     result['genre_ids'].map { |id| MoviedbClient::GENRES[id] }.compact
   end
 
+  def reliable?(result)
+    result['popularity'] > 1.5
+  end
+
   private
 
   def moviedb_client


### PR DESCRIPTION
Introduce a new scrape attribute which indicates the reliability of a result. By default every scraped result is marked as reliable. Currently, only the `MovieScraper` and the `TvScraper` define a measure for the reliability of their results. By filtering all results that are below a minimum quality value, we discard irrelevant findings.

before
<img width="1440" alt="relevant_before" src="https://cloud.githubusercontent.com/assets/827143/23828164/947187d2-06c9-11e7-9b1b-4bbfb7b0e41b.png">

after
<img width="1440" alt="relevant_after" src="https://cloud.githubusercontent.com/assets/827143/23828166/9bfee5ee-06c9-11e7-942b-aad350cbfbc2.png">

## TODOS

+ [ ] Use more appropriate names / enhance documentation.
+ [ ] Implement a new filter to discard results by their reliability.
+ [ ] Implement a _missing image_ filter,  which filters all results without an image.
